### PR TITLE
Allow App to install on external device

### DIFF
--- a/dring/src/main/AndroidManifest.xml
+++ b/dring/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.couchsource.dring.application"
-    android:installLocation="internalOnly">
+    android:installLocation="auto">
 
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.VIBRATE" />


### PR DESCRIPTION
This feature is handy, when users have devices with low internal storage they can move to external storage.
